### PR TITLE
Implement join tables

### DIFF
--- a/lib/base.ex
+++ b/lib/base.ex
@@ -27,6 +27,7 @@ defmodule Filtery.Base do
           end)
           |> Enum.group_by(fn
             {_, {:ref, _}} -> :ref
+            {_, {:ref, _, _}} -> :ref
             _ -> :filter
           end)
 
@@ -34,7 +35,7 @@ defmodule Filtery.Base do
 
         query
         |> filter_columns(column_filter, opts)
-        |> join_ref(grouped_by_type[:ref])
+        |> join_ref(grouped_by_type[:ref], opts)
         |> sort(sort)
       end
 
@@ -76,8 +77,8 @@ defmodule Filtery.Base do
           ft = filter(key, val)
 
           cond do
-            is_nil(acc) -> dynamic([q], ^ft)
-            ft -> dynamic([q], ^acc and ^ft)
+            is_nil(acc) -> dynamic([..., q], ^ft)
+            ft -> dynamic([..., q], ^acc and ^ft)
             true -> acc
           end
         end)
@@ -88,8 +89,8 @@ defmodule Filtery.Base do
           ft = filter(key, val)
 
           cond do
-            is_nil(acc) -> dynamic([q], ^ft)
-            ft -> dynamic([q], ^acc or ^ft)
+            is_nil(acc) -> dynamic([..., q], ^ft)
+            ft -> dynamic([..., q], ^acc or ^ft)
             true -> acc
           end
         end)
@@ -99,7 +100,7 @@ defmodule Filtery.Base do
         d_query = filter(:and, filters)
 
         if d_query do
-          dynamic([q], not (^d_query))
+          dynamic([..., q], not (^d_query))
         end
       end
     end
@@ -108,46 +109,46 @@ defmodule Filtery.Base do
   defmacro __before_compile__(_env) do
     quote do
       def filter(column, {:gt, value}) do
-        dynamic([q], field(q, ^column) > ^value)
+        dynamic([..., q], field(q, ^column) > ^value)
       end
 
       def filter(column, {:gte, value}) do
-        dynamic([q], field(q, ^column) >= ^value)
+        dynamic([..., q], field(q, ^column) >= ^value)
       end
 
       def filter(column, {:lt, value}) do
-        dynamic([q], field(q, ^column) < ^value)
+        dynamic([..., q], field(q, ^column) < ^value)
       end
 
       def filter(column, {:lte, value}) do
-        dynamic([q], field(q, ^column) <= ^value)
+        dynamic([..., q], field(q, ^column) <= ^value)
       end
 
       def filter(column, {:eq, nil}) do
-        dynamic([q], is_nil(field(q, ^column)))
+        dynamic([..., q], is_nil(field(q, ^column)))
       end
 
       def filter(column, {:eq, :is_nil}) do
-        dynamic([q], is_nil(field(q, ^column)))
+        dynamic([..., q], is_nil(field(q, ^column)))
       end
 
       def filter(column, {:eq, value}) do
-        dynamic([q], field(q, ^column) == ^value)
+        dynamic([..., q], field(q, ^column) == ^value)
       end
 
       def filter(column, {:ne, value}) when value in [nil, :is_nil] do
-        dynamic([q], not is_nil(field(q, ^column)))
+        dynamic([..., q], not is_nil(field(q, ^column)))
       end
 
       def filter(column, {:ne, value}) do
-        dynamic([q], field(q, ^column) != ^value)
+        dynamic([..., q], field(q, ^column) != ^value)
       end
 
       def filter(column, {:not, value}) do
         ft = filter(column, value)
 
         if ft do
-          dynamic([q], not (^ft))
+          dynamic([..., q], not (^ft))
         end
       end
 
@@ -156,11 +157,11 @@ defmodule Filtery.Base do
       end
 
       def filter(column, {:in, values}) do
-        dynamic([q], field(q, ^column) in ^values)
+        dynamic([..., q], field(q, ^column) in ^values)
       end
 
       def filter(column, {:nin, values}) do
-        dynamic([q], field(q, ^column) not in ^values)
+        dynamic([..., q], field(q, ^column) not in ^values)
       end
 
       # extra filters
@@ -207,15 +208,15 @@ defmodule Filtery.Base do
       def filter(_, {:ibetween, _}), do: nil
 
       def filter(column, {:has, value}) do
-        dynamic([q], ^value in field(q, ^column))
+        dynamic([..., q], ^value in field(q, ^column))
       end
 
       def filter(column, {:like, value}) do
-        dynamic([q], like(field(q, ^column), ^"%#{value}%"))
+        dynamic([..., q], like(field(q, ^column), ^"%#{value}%"))
       end
 
       def filter(column, {:ilike, value}) do
-        dynamic([q], ilike(field(q, ^column), ^"%#{value}%"))
+        dynamic([..., q], ilike(field(q, ^column), ^"%#{value}%"))
       end
 
       def filter(column, {:contains, value}) do
@@ -258,21 +259,51 @@ defmodule Filtery.Base do
       def join_ref(query, ref, opts \\ [])
       def join_ref(query, nil, _), do: query
 
-      def join_ref(query, refs, query_opts) when is_list(refs) do
-        Enum.reduce(refs, query, fn {column, {:ref, ref_filter}}, query ->
-          join_ref(query, {column, ref_filter}, query_opts)
+      def join_ref(query, refs, opts) when is_list(refs) do
+        Enum.reduce(refs, query, fn
+          {column, {:ref, join_qual, ref_filter}}, query ->
+            do_join(query, join_qual, {column, ref_filter}, opts)
+
+          {column, {:ref, ref_filter}}, query ->
+            do_join(query, {column, ref_filter}, opts)
         end)
       end
 
-      def join_ref(query, {column, {model, filter, opts}}, query_opts) do
-        foreign_key = Keyword.get(opts, :foreign_key, :"#{column}_id")
-        references = Keyword.get(opts, :references, :id)
+      defp do_join(query, qual \\ :inner, {column, filter}, opts)
+           when qual in [:inner, :left, :right, :cross, :full, :inner_lateral, :left_lateral] do
+        binding = opts[:binding]
 
-        ref_query = __MODULE__.apply(model, filter, query_opts)
+        query =
+          if binding do
+            join(query, qual, [{^binding, a}], b in assoc(a, ^column))
+          else
+            join(query, qual, [a], b in assoc(a, ^column))
+          end
 
-        join(query, :inner, [a], b in ^ref_query,
-          on: field(a, ^foreign_key) == field(b, ^references)
-        )
+        # WARNING this is a hack because Ecto only allow hard-coded `:as` name binding
+
+        aliases = query.aliases
+
+        if Map.has_key?(aliases, column) do
+          raise ArgumentError, "Do not allow 2 ref binding with the same name"
+        end
+
+        aliases =
+          case Enum.map(aliases, &elem(&1, 1)) do
+            [] ->
+              %{column => 1}
+
+            positions ->
+              max = Enum.max(positions)
+              Map.put(aliases, column, max + 1)
+          end
+
+        # Update the alias map
+        query = struct(query, aliases: aliases)
+
+        # udpate option with new name binding
+        opts = Keyword.put(opts, :binding, column)
+        __MODULE__.apply(query, filter, opts)
       end
 
       def join_ref(query, _, _), do: query

--- a/lib/filtery.ex
+++ b/lib/filtery.ex
@@ -198,6 +198,59 @@ defmodule Filtery do
   ```
 
   Within the body of `filter/2` function using `dynamic` to compose your condtion and return a `dynamic`
+
+  ## V. Joining tables 
+
+  **`Filtery` defines a special operator `ref` to join table**
+
+  *Syntax*: `<field>: {:ref, <qualifier>, <filter on joined table>}`
+
+  If `qualifier` is skipped, then `:inner` join is used by default.
+
+  ```elixir
+  query = Filtery.apply(Post, %{comments: {:ref, %{
+                                      approved: true,
+                                      content: {:like, "filtery"}
+                                   }}})
+  ```
+
+  And then you can use **Name binding** to do further query
+
+  ```elixir
+  query = where(query, [comments: c], c.published_at > ^xday_ago)
+  ```
+
+
+
+  **Qualifiers**
+
+  By default `Filtery` join using `:inner` qualifier. You can use one of ``:inner`, `:left`, `:right`, `:cross`, `:full`, `:inner_lateral` or `:left_lateral` qualifier as defined by Ecto.
+
+
+
+  ### **You can filter with nested `ref`**
+
+  ```elixir
+  Filtery.apply(Post, %{comments: {:ref, %{
+                                      approved: true,
+                                      user: {:ref, %{
+                                                name: {:like, "Tom"}
+                                             }}
+                                   }}})
+  ```
+
+
+
+
+
+  ### Important Notes on `ref` operator
+
+  - Field name must be the association name in your schema because `Filtery` use `assoc` to build join query.
+
+    In the above example, `Post` schema must define association `has_many: :comments, Comment`
+
+  - Not allow 2 ref with same name because the name is used as alias `:as` in join query, so it can only use one.
+
   """
 
   use Filtery.Base


### PR DESCRIPTION
  *Syntax*: `<field>: {:ref, <qualifier>, <filter on joined table>}`

  If `qualifier` is skipped, then `:inner` join is used by default.

  ```elixir
  query = Filtery.apply(Post, %{comments: {:ref, %{
                                      approved: true,
                                      content: {:like, "filtery"}
                                   }}})
  ```

  And then you can use **Name binding** to do further query

  ```elixir
  query = where(query, [comments: c], c.published_at > ^xday_ago)
  ```
